### PR TITLE
Everything uses pthreads now

### DIFF
--- a/Configfile
+++ b/Configfile
@@ -46,6 +46,8 @@ COMPILEOPTS += `ppkg-config libnotify --optional --have LIBNOTIFY --cflags`
 LINKOPTS    += `ppkg-config libnotify --optional --have LIBNOTIFY --libs`
 COMPILEOPTS += `ppkg-config libbase64-1 --cflags`
 LINKOPTS    += `ppkg-config libbase64-1 --libs`
+COMPILEOPTS += -pthread
+LINKOPTS    += -pthread
 
 # Try to match this with git's version number
 GENERATE    += version.h
@@ -282,7 +284,6 @@ SOURCES     += mhimap-idle.c++
 BINARIES    += mhng-daemon
 AUTODEPS     = false
 DEPLIBS     += mhng
-LINKOPTS    += -pthread
 SOURCES     += mhng-daemon.c++
 
 ##############################################################################


### PR DESCRIPTION
I'm not sure if this was a change in my dependencies or in glibc, but it
doesn't really hurt to just use pthreads everywhere.