### PR TITLE
Allow mhng-pipe-comp_stdin to handle attachments

### DIFF
--- a/Configfile
+++ b/Configfile
@@ -307,6 +307,7 @@ BINARIES    += mhng-pipe-comp_stdin
 AUTODEPS     = false
 DEPLIBS     += mhng
 SOURCES     += mhng-pipe-comp_stdin.c++
+TESTSRC     += attachment_base64.bash
 
 # Produces the raw contents of the given set of messages on stdout.
 # This is pretty similar to "mhng-show", but it has two important

--- a/src/mhng-pipe-comp_stdin.c++
+++ b/src/mhng-pipe-comp_stdin.c++
@@ -87,7 +87,7 @@ int main(int argc, const char **argv)
          * perform any sort of necessary address book lookups. */
         std::vector<std::string> lookup;
         std::map<std::string, std::vector<std::string>> oheaders;
-        for (const auto& header: raw_mime->body()->headers()) {
+        for (const auto& header: raw_mime->root()->headers()) {
             if (header->match({"From", "To", "CC", "BCC"})) {
                 auto k = header->key();
                 for (const auto v: header->split_commas()) {
@@ -113,7 +113,7 @@ int main(int argc, const char **argv)
         }
 
         lookup.push_back("\n");
-        for (const auto& body: raw_mime->body()->body_raw())
+        for (const auto& body: raw_mime->root()->raw())
             lookup.push_back(body);
         mime = std::make_shared<mhng::mime::message>(lookup);
     }

--- a/test/mhng-pipe-comp_stdin/attachment_base64.bash
+++ b/test/mhng-pipe-comp_stdin/attachment_base64.bash
@@ -1,0 +1,30 @@
+#include "harness_start.bash"
+
+ARGS="drafts 1"
+
+cat >in.test <<"EOF"
+To: REDATCED2@example.com
+Message-ID: <REDACTED@email.amazonses.com>
+Subject: Shipping Label for your Trade-In (TRN-REDACTED4)
+MIME-Version: 1.0
+Content-Type: multipart/alternative; 
+	boundary="----=_Part_REDATCED3"
+Date: Sat, 10 Dec 2016 20:03:44 +0000
+
+------=_Part_REDATCED3
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+Look, content!
+------=_Part_REDATCED3
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: base64
+
+aGVsbG8K
+------=_Part_REDATCED3--
+
+EOF
+
+cp in.test out.test
+
+#include "harness_end.bash"

--- a/test/mhng-pipe-comp_stdin/harness_end.bash
+++ b/test/mhng-pipe-comp_stdin/harness_end.bash
@@ -1,0 +1,5 @@
+sqlite3 $MHNG_MAILDIR/metadata.sqlite3 .dump
+
+$PTEST_BINARY < in.test
+
+$(dirname "$PTEST_BINARY")/mhng-pipe-show_stdout $ARGS > out.test

--- a/test/mhng-pipe-comp_stdin/harness_start.bash
+++ b/test/mhng-pipe-comp_stdin/harness_start.bash
@@ -1,0 +1,1 @@
+../mhng-show/harness_start.bash


### PR DESCRIPTION
This was just a bug: mhng-pipe-comp_stdin used to eat any attachments
because it would search for a body part and pass just that through.