### PR TITLE
Add a newline in add_header

### DIFF
--- a/Configfile
+++ b/Configfile
@@ -192,6 +192,7 @@ TESTSRC     += two-cc.bash
 TESTSRC     += multi-cc.bash
 TESTSRC     += multi-to.bash
 TESTSRC     += linux-cc.bash
+TESTSRC     += eating_date.bash
 
 BINARIES    += mhng-repl
 AUTODEPS     = false
@@ -311,6 +312,7 @@ AUTODEPS     = false
 DEPLIBS     += mhng
 SOURCES     += mhng-pipe-comp_stdin.c++
 TESTSRC     += attachment_base64.bash
+TESTSRC     += eating_date.bash
 
 # Produces the raw contents of the given set of messages on stdout.
 # This is pretty similar to "mhng-show", but it has two important

--- a/src/libmhng/mime/part.c++
+++ b/src/libmhng/mime/part.c++
@@ -664,7 +664,7 @@ void mime::part::add_header(const header_ptr& header)
         if (added == false && (strlen(raw.c_str()) == 1)) {
             added = true;
             for (const auto& hraw: header->raw())
-                new_raw.push_back(hraw);
+                new_raw.push_back(hraw + "\n");
         }
 
         new_raw.push_back(raw);

--- a/src/mhng-pipe-comp_stdin.c++
+++ b/src/mhng-pipe-comp_stdin.c++
@@ -136,8 +136,10 @@ int main(int argc, const char **argv)
     /* Date-stamp the message with the current date. */
     if (mime->header("Date").size() == 0) {
         auto date = mhng::date::now();
-        mime->add_header("Date", date->local());
-        mime->body()->add_header("Date", date->local());
+        auto env_date = getenv("MHNG_COMP_DATE");
+        auto date_str = (env_date == NULL) ? date->local() : std::string(env_date);
+        mime->add_header("Date", date_str);
+        mime->body()->add_header("Date", date_str);
     }
 
     /* Generate a unique identifier that cooresponds to this message,
@@ -175,8 +177,11 @@ int main(int argc, const char **argv)
         char message_id[BUFFER_SIZE];
         snprintf(message_id, BUFFER_SIZE, "<mhng-%s@%s>", uuid_str, hostname);
 
-        mime->add_header("Message-ID", message_id);
-        mime->body()->add_header("Message-ID", message_id);
+        auto message_id_env = getenv("MHNG_COMP_MESSAGE_ID");
+        auto message_id_str = (message_id_env == NULL) ? std::string(message_id) : std::string(message_id_env);
+
+        mime->add_header("Message-ID", message_id_str);
+        mime->body()->add_header("Message-ID", message_id_str);
     }
 
     /* Go ahead and insert this message into the database. */

--- a/test/mhng-comp/eating_date.bash
+++ b/test/mhng-comp/eating_date.bash
@@ -1,0 +1,33 @@
+#include "harness_start.bash"
+
+ARGS="drafts 1"
+export MHNG_COMP_DATE="Mon Nov 13 14:40:14 PST 2017"
+export MHNG_COMP_MESSAGE_ID="<mhng-TEST@TEST>"
+
+cat >"$MHNG_EDITOR" <<"EOF"
+#!/bin/bash
+
+cat in.test > $1
+EOF
+
+cat >in.test <<"EOF"
+To: REDATCED2@example.com
+From: REDACTOR3@example.com
+Subject: Shipping Label for your Trade-In (TRN-REDACTED4)
+
+Test Line 1
+Test Line 2
+EOF
+
+cat >out.gold <<"EOF"
+To: REDATCED2@example.com
+From: REDACTOR3@example.com
+Subject: Shipping Label for your Trade-In (TRN-REDACTED4)
+Date: Mon Nov 13 14:40:14 PST 2017
+Message-ID: <mhng-TEST@TEST>
+
+Test Line 1
+Test Line 2
+EOF
+
+#include "harness_end.bash"

--- a/test/mhng-pipe-comp_stdin/eating_date.bash
+++ b/test/mhng-pipe-comp_stdin/eating_date.bash
@@ -1,0 +1,27 @@
+#include "harness_start.bash"
+
+ARGS="drafts 1"
+export MHNG_COMP_DATE="Mon Nov 13 14:40:14 PST 2017"
+export MHNG_COMP_MESSAGE_ID="<mhng-TEST@TEST>"
+
+cat >in.test <<"EOF"
+To: REDATCED2@example.com
+From: REDACTOR3@example.com
+Subject: Shipping Label for your Trade-In (TRN-REDACTED4)
+
+Test Line 1
+Test Line 2
+EOF
+
+cat >out.gold <<"EOF"
+Subject: Shipping Label for your Trade-In (TRN-REDACTED4)
+From: REDACTOR3@example.com
+To: REDATCED2@example.com
+Date: Mon Nov 13 14:40:14 PST 2017
+Message-ID: <mhng-TEST@TEST>
+
+Test Line 1
+Test Line 2
+EOF
+
+#include "harness_end.bash"


### PR DESCRIPTION
add_header didn't produce a newline, so as a result the next line was
eaten by the header.  If this header was the last one in line, then it
would eat the first line of the message.

I didn't notice this because most of the time I had a date and message
ID filled out by git send-email.