### PR TITLE
Don't abort on missing message files

### DIFF
--- a/src/libmhng/message.c++
+++ b/src/libmhng/message.c++
@@ -73,10 +73,8 @@ void message::remove(void)
     imap->update_purge(atoi(_uid.c_str()), true);
 
     int err = unlink(full_path().c_str());
-    if (err < 0) {
-        perror("Unable to remove message file");
-        abort();
-    }
+    if (err < 0)
+        perror("Unable to remove message file, your mailbox may be corrupted");
 }
 
 std::vector<address_ptr> message::header_addr(const std::string name) const


### PR DESCRIPTION
I'm not sure how this happened, and I'm a bit scared about it.  With the
abort that was in there, your mailbox was essentially just in an
unrecovorable state.  This fix at least allows you to recover, but it is
a bit funky.