### PR TITLE
Run Travis on newer GCC versions as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,21 @@ addons:
       - g++-5
       - gcc-6
       - g++-6
+      - gcc-7
+      - g++-7
+      - gcc-8
+      - g++-8
+      - gcc-9
+      - g++-9
 
 matrix:
   include:
     - env: TRAVIS_CC=gcc-4.9   TRAVIS_CXX=g++-4.9
     - env: TRAVIS_CC=gcc-5     TRAVIS_CXX=g++-5
     - env: TRAVIS_CC=gcc-6     TRAVIS_CXX=g++-6
+    - env: TRAVIS_CC=gcc-7     TRAVIS_CXX=g++-7
+    - env: TRAVIS_CC=gcc-8     TRAVIS_CXX=g++-8
+    - env: TRAVIS_CC=gcc-9     TRAVIS_CXX=g++-9
 
 before_install:
   - export PATH="${HOME}/dependencies/install/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - export PKG_CONFIG_PATH="${HOME}/dependencies/install/lib/pkgconfig"
   - export CC=$TRAVIS_CC
   - export CXX=$TRAVIS_CXX
-  - PCONFIGURE_VERSION=0.11.10
+  - PCONFIGURE_VERSION=0.12.5
   - PSQLITE_VERSION=0.0.3
   - PUTIL_VERSION=0.0.4
   - LIBBASE64_VERSION=1.0.0_p3


### PR DESCRIPTION
I'm using GCC 8.3 locally, but I don't see any reason to abandon 4.9
yet.

Signed-off-by: Palmer Dabbelt <palmer@dabbelt.com>