### PR TITLE
Kill existing daemons before starting new ones

### DIFF
--- a/src/mhng-launch-gui-daemons.bash
+++ b/src/mhng-launch-gui-daemons.bash
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+killall mhng-launch-gui-daemons
+killall mhng-daemon
+killall mhng-notify
+
 ( while true
 do
     mhng-daemon &>> ~/.mhng/daemon.log


### PR DESCRIPTION
I have mhng-launch-gui-daemons in my swayrc.  Since sway doesn't kill
children when existing, I instead kill them when starting another set.

Signed-off-by: Palmer Dabbelt <palmer@dabbelt.com>