### PR TITLE
libmhng::mime: Fix decoding of base64 headers

### DIFF
--- a/src/libmhng/mime/base64.c++
+++ b/src/libmhng/mime/base64.c++
@@ -27,6 +27,11 @@
 
 std::vector<uint8_t> base64_decode(const std::string& in)
 {
+    if (in[in.size() - 1] != '\n') {
+        fprintf(stderr, "base64_decode('%s'): trailing newline expected\n", in.c_str());
+        abort();
+    }
+
     auto out_len = base64_declen(in.size()) + 5;
     auto out = std::vector<uint8_t>(out_len);
     auto out_unused = 5 + (
@@ -37,6 +42,11 @@ std::vector<uint8_t> base64_decode(const std::string& in)
     int err;
     if ((err = base64_decode(in.c_str(), &out[0], out_len)) < 0) {
         fprintf(stderr, "base64_decode('%s', out, %lu) => %d\n", in.c_str(), out_len, err);
+        fprintf(stderr, "    in.size(): %lu\n", in.size());
+        fprintf(stderr, "    in[in.size() - 4]: %c\n", in[in.size() - 4]);
+        fprintf(stderr, "    in[in.size() - 3]: %c\n", in[in.size() - 3]);
+        fprintf(stderr, "    in[in.size() - 2]: %c\n", in[in.size() - 2]);
+        fprintf(stderr, "    in[in.size() - 1]: %c\n", in[in.size() - 1]);
         abort();
     }
 

--- a/src/libmhng/mime/header.c++
+++ b/src/libmhng/mime/header.c++
@@ -72,7 +72,13 @@ std::string mime::header::utf8(void) const
                     fprintf(stderr, "  line: '%s'\n", line + i);
                     abort();
                 }
-                strstr(base64, "?=")[0] = '\0';
+
+                /* base64_decode() expects a newline at the end of the input
+                 * string, and it's easier to just whack it in there than to
+                 * change the mime part parser.. */
+                auto end = strstr(base64, "?=");
+                end[0] = '\n';
+                end[1] = '\0';
 
                 auto dec = base64_decode(base64);
                 auto dec_str = base64_array2string(dec);


### PR DESCRIPTION
The base64 decoder expects a newline at the end of the line, but one
wasn't being provided as part of the header checking.

Signed-off-by: Palmer Dabbelt <palmer@dabbelt.com>