### PR TITLE
Allow multiple accounts to be added

### DIFF
--- a/src/mhng-add-account.c++
+++ b/src/mhng-add-account.c++
@@ -7,13 +7,6 @@
 int main(int argc, const char **argv)
 {
     auto args = mhng::args::parse_account(argc, argv);
-
-    if (args->mbox()->accounts().size() > 0) {
-        std::cerr << "MHng currently only supports a single account\n";
-        return 1;
-    }
-
     args->mbox()->add_account(args->account());
-
     return 0;
 }


### PR DESCRIPTION
As far as I can tell this works now, so I'm going to disable the check that
prevents users from adding multiple accounts.

Signed-off-by: Palmer Dabbelt <palmerdabbelt@google.com>