### PR TITLE
Treat ks_c_5601-1987 as EUC-KR

### DIFF
--- a/src/libmhng/mime/header.c++
+++ b/src/libmhng/mime/header.c++
@@ -102,6 +102,9 @@ std::string mime::header::utf8(void) const
                 out_offset = strlen(qp);
             }
 
+            if (strcmp(charset, "ks_c_5601-1987") == 0)
+                strcpy(charset, "EUC-KR");
+
             iconv_t icd = iconv_open("UTF-8", charset);
 
             char *raw_p = raw;


### PR DESCRIPTION
I probably can't read any of this so it's not like I'm going to be able to tell
if this is correct, but it looks like iconv doesn't support this encoding and I
can just use a supported one instead.  I'm not going to bother testing it.

See https://marc.info/?l=kde-i18n-doc&m=100396886120761&w=2 for more info.

Signed-off-by: Palmer Dabbelt <palmerdabbelt@google.com>