### PR TITLE
Properly pad UTF8 strings

### DIFF
--- a/src/libmhng/util/string.c++
+++ b/src/libmhng/util/string.c++
@@ -2,42 +2,39 @@
 /* SPDX-License-Identifier: GPL-2.0+ OR Apache-2.0 OR BSD-3-Clause */
 
 #include "string.h++"
-#include <cstring>
+#include <codecvt>
+#include <locale>
 
-std::string mhng::util::string::utf8_pad_to_length(std::string base, size_t length, char element)
+std::string mhng::util::string::utf8_pad_to_cols(std::string base, size_t cols)
 {
-    auto out = new char[length*4+1];
+    if (utf8_cols(base) > cols)
+        return utf8_crop_to_cols(base, cols);
 
-    memset(out, element, length*4+1);
-    out[length*4] = '\0';
-    strncpy(out, base.c_str(), strlen(base.c_str()));
+    auto out = std::string(base);
+    for (size_t i = 0; i < cols - utf8_cols(base); ++i)
+        out = out + " ";
+    return out;
+}
 
-    /* This is a pretty crude attempt at UTF8 decoding: it considers the number
-     * of bytes in the input string, but assumes there is a single codepoint
-     * for all the outputs.  It works well enough for the European-style two
-     * byte accents, but that's going to be about it.
-     *
-     * I probably should have figured out if iconv can do this, but I'm stuck
-     * in China and don't have real internet access so I didn't want to deal
-     * with the headaches. */
-    for (size_t i = 0; i < strlen(base.c_str()); ++i) {
-        if ((base[i] & (0x80 + 0x40 + 0x20)) == (0x80 + 0x40)) {
-            i += 1;
-            length += 1;
-        }
-        else if ((base[i] & (0x80 + 0x40 + 0x20 + 0x10)) == (0x80 + 0x40 + 0x20)) {
-            i += 2;
-            length += 2;
-        }
-        else if ((base[i] & (0x80 + 0x40 + 0x20 + 0x10 + 0x08)) == (0x80 + 0x40 + 0x20 + 0x10)) {
-            i += 3;
-            length += 3;
-        }
+std::string mhng::util::string::utf8_crop_to_cols(std::string base, size_t cols)
+{
+    if (utf8_cols(base) < cols)
+        return base;
+
+    auto prev = std::string("");
+    auto next = prev + base[0];
+    for (size_t i = 1; i < base.size(); ++i) {
+        prev = next;
+        next = next + base[i];
+        if (utf8_cols(next) > cols)
+            return prev;
     }
-        
-    out[length] = '\0';
 
-    auto ostr = std::string(out);
-    delete out;
-    return ostr;
+    abort();
+}
+
+size_t mhng::util::string::utf8_cols(std::string in)
+{
+    std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> conv;
+    return conv.from_bytes(in).size();
 }

--- a/src/libmhng/util/string.h++
+++ b/src/libmhng/util/string.h++
@@ -11,7 +11,9 @@ namespace mhng {
     namespace util {
         namespace string {
             /* Performs a UTF8-aware padding. */
-            std::string utf8_pad_to_length(std::string base, size_t length, char element = ' ');
+            std::string utf8_pad_to_cols(std::string base, size_t cols);
+            std::string utf8_crop_to_cols(std::string base, size_t cols);
+            size_t utf8_cols(std::string in);
 
             /* Converts a string to lower case. */
             static inline std::string tolower(std::string in)

--- a/src/mhng-scan.c++
+++ b/src/mhng-scan.c++
@@ -52,7 +52,7 @@ int main(int argc, const char **argv)
             seq_width = 8;
     }
 
-    size_t subject_width = terminal_width - from_width - seq_width - 11;
+    size_t subject_width = terminal_width - from_width - seq_width - 10;
 #endif
 
     /* At this point that argument list contains the entire set of
@@ -74,14 +74,18 @@ int main(int argc, const char **argv)
                subj.c_str()
             );
 #else
-        printf("%s%c %*u %s %s %s%c%s\n",
+        auto subj_crop =
+            mhng::util::string::utf8_cols(subj) > subject_width
+            ? mhng::util::string::utf8_crop_to_cols(subj, subject_width - 1) + "\\"
+            : subj;
+
+        printf("%s%c %*u %s %s %s%s\n",
                msg->unread() ? terminal_bold : "",
                msg->cur() ? '*' : ' ',
                (int)seq_width, msg->seq()->to_uint(),
                msg->first_date()->ddmm().c_str(),
-               mhng::util::string::utf8_pad_to_length(from->nom(), from_width).c_str(),
-               mhng::util::string::utf8_pad_to_length(subj, subject_width).c_str(),
-               strlen(subj.c_str()) > subject_width ? '\\' : ' ',
+               mhng::util::string::utf8_pad_to_cols(from->nom(), from_width).c_str(),
+               subj_crop.c_str(),
                terminal_norm
             );
 #endif

--- a/test/mhng-scan/utf.bash
+++ b/test/mhng-scan/utf.bash
@@ -15,8 +15,8 @@ COMMIT TRANSACTION;
 EOF
 
 cat > out.gold <<EOF
-*  1 12/01 fröm@example.com          test                                       
-   2 12/01 from@example.com          test                                       
+*  1 12/01 fröm@example.com          test
+   2 12/01 from@example.com          test
 EOF
 
 #include "harness_end.bash"


### PR DESCRIPTION
That UTF8 padding support I added was a mess, hopefully this one fixes it.

Signed-off-by: Palmer Dabbelt <palmerdabbelt@google.com>