### PR TITLE
Add the --mime argument, which is only implemented for repl

### DIFF
--- a/src/libmhng/args.c++
+++ b/src/libmhng/args.c++
@@ -131,6 +131,7 @@ args_ptr args::parse(int argc, const char **argv, int flags)
     unknown<std::string> account;
 
     std::vector<std::string> attach;
+    std::vector<int> mime;
 
     auto mhng_folder = default_mhng_folder_path();
 
@@ -208,6 +209,9 @@ args_ptr args::parse(int argc, const char **argv, int flags)
             thread = true;
         } else if (strcmp(argv[i], "--no-mailrc") == 0) {
             nomailrc = true;
+        } else if (strcmp(argv[i], "--mime") == 0) {
+            mime.push_back(atoi(argv[i+1]));
+            i++;
         } else {
             folders_written = true;
             folder_names.push_back(argv[i]);
@@ -272,6 +276,7 @@ args_ptr args::parse(int argc, const char **argv, int flags)
                                           nomailrc,
                                           attach,
                                           account,
+                                          mime,
                                           nullptr);
         } else if (flags & pf_nom) {
             std::vector<message_ptr> messages;
@@ -284,6 +289,7 @@ args_ptr args::parse(int argc, const char **argv, int flags)
                                           nomailrc,
                                           attach,
                                           account,
+                                          mime,
                                           nullptr);
         } else {
             std::vector<message_ptr> messages;
@@ -307,6 +313,7 @@ args_ptr args::parse(int argc, const char **argv, int flags)
                                           nomailrc,
                                           attach,
                                           account,
+                                          mime,
                                           cur->fake());
         }
     }
@@ -365,6 +372,7 @@ args_ptr args::parse(int argc, const char **argv, int flags)
                                      nomailrc,
                                      attach,
                                      account,
+                                     mime,
                                      nullptr);
     }
 
@@ -379,6 +387,7 @@ args_ptr args::parse(int argc, const char **argv, int flags)
                                   nomailrc,
                                   attach,
                                   account,
+                                  mime,
                                   nullptr);
 }
 

--- a/src/libmhng/args.h++
+++ b/src/libmhng/args.h++
@@ -49,6 +49,7 @@ namespace mhng {
         unknown<bool> _nomailrc;
         std::vector<std::string> _attach;
         unknown<std::string> _account;
+        std::vector<int> _mime;
 
         /* Sometimes the current message is actually fake. */
         fake_message_ptr _fake_current;
@@ -66,6 +67,7 @@ namespace mhng {
              const unknown<bool>& nomailrc,
              const std::vector<std::string>& attach,
              const unknown<std::string>& account,
+             const std::vector<int>& mime,
              const fake_message_ptr& fake_current)
         : _messages(messages),
           _folders(folders),
@@ -76,6 +78,7 @@ namespace mhng {
           _nomailrc(nomailrc),
           _attach(attach),
           _account(account),
+          _mime(mime),
           _fake_current(fake_current)
         {}
 
@@ -90,6 +93,7 @@ namespace mhng {
         const mailbox_ptr& mbox(void) const { return _mbox; }
         const decltype(_attach)& attach(void) const { return _attach; }
         std::string const account(void) const { return _account.data(); }
+        const decltype(_mime)& mime(void) const { return _mime; }
 
         bool stdout(void) const
             { return _stdout.known() == true && _stdout.data() == true; }


### PR DESCRIPTION
Some people keep including patches as attachments rather than sending their
code via git-send-email.  Rather than asking people to re-send patches I'm just
going to start inlining their code myself.

Signed-off-by: Palmer Dabbelt <palmerdabbelt@google.com>